### PR TITLE
修改 当 checkCol 和 multiSelect搭配使用时, 原来单击行只可进行选择,现在是切换.

### DIFF
--- a/src/mmGrid.js
+++ b/src/mmGrid.js
@@ -547,6 +547,8 @@
                 }
                 if(!$this.parent().hasClass('selected')){
                     that.select($this.parent().index());
+                }else{
+                    that.deselect($this.parent().index());
                 }
             });
 


### PR DESCRIPTION
存在选项框,并且可以进行多选的情况下,单击行可进行选择. 再次单击已经选中的行却无法取消选择.
我觉得让再次单击选中行的时候.可以切换选中状态是更好的选择. 并且做到这件事并不是很复杂. 我做了个补丁,希望这样的改变对大家有用.
